### PR TITLE
Agregar analizador léxico de expresiones

### DIFF
--- a/analizador_lexico.py
+++ b/analizador_lexico.py
@@ -1,0 +1,49 @@
+import re
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Token:
+    tipo: str
+    valor: str
+
+# Definimos las expresiones regulares para cada tipo de token
+TOKEN_SPEC = [
+    ("NUMBER",   r"\d+\.?\d*"),      # Números enteros o decimales
+    ("EQ",       r"=="),              # Igualdad
+    ("NE",       r"!="),             # Distinto
+    ("GE",       r">="),             # Mayor o igual
+    ("LE",       r"<="),             # Menor o igual
+    ("GT",       r">"),              # Mayor que
+    ("LT",       r"<"),              # Menor que
+    ("ASSIGN",   r"="),              # Asignación
+    ("OP",       r"[+\-*/^]"),      # Operadores aritméticos
+    ("LPAREN",   r"\("),            # Paréntesis izquierdo
+    ("RPAREN",   r"\)"),            # Paréntesis derecho
+    ("IDENT",    r"[A-Za-z_]+"),     # Variables
+    ("SKIP",     r"[ \t]+"),        # Espacios en blanco
+    ("MISMATCH", r".")               # Cualquier otro carácter
+]
+
+def analizar(cadena: str) -> List[Token]:
+    """Analiza la cadena y retorna una lista de tokens."""
+    token_regex = "|".join(f"(?P<{name}>{pattern})" for name, pattern in TOKEN_SPEC)
+    regex = re.compile(token_regex)
+    tokens: List[Token] = []
+    for match in regex.finditer(cadena):
+        tipo = match.lastgroup
+        valor = match.group()
+        if tipo == "SKIP":
+            continue
+        if tipo == "MISMATCH":
+            raise ValueError(f"Carácter inesperado: {valor}")
+        tokens.append(Token(tipo, valor))
+    return tokens
+
+if __name__ == "__main__":
+    expresion = input("Ingrese la expresión a analizar: ")
+    try:
+        for tok in analizar(expresion):
+            print(f"{tok.valor}\t{tok.tipo}")
+    except ValueError as e:
+        print(e)

--- a/analizador_lexico.py
+++ b/analizador_lexico.py
@@ -8,21 +8,22 @@ class Token:
     valor: str
 
 # Definimos las expresiones regulares para cada tipo de token
+# Los nombres de los tokens se encuentran en español para mostrarlos así en la interfaz
 TOKEN_SPEC = [
-    ("NUMBER",   r"\d+\.?\d*"),      # Números enteros o decimales
-    ("EQ",       r"=="),              # Igualdad
-    ("NE",       r"!="),             # Distinto
-    ("GE",       r">="),             # Mayor o igual
-    ("LE",       r"<="),             # Menor o igual
-    ("GT",       r">"),              # Mayor que
-    ("LT",       r"<"),              # Menor que
-    ("ASSIGN",   r"="),              # Asignación
-    ("OP",       r"[+\-*/^]"),      # Operadores aritméticos
-    ("LPAREN",   r"\("),            # Paréntesis izquierdo
-    ("RPAREN",   r"\)"),            # Paréntesis derecho
-    ("IDENT",    r"[A-Za-z_]+"),     # Variables
-    ("SKIP",     r"[ \t]+"),        # Espacios en blanco
-    ("MISMATCH", r".")               # Cualquier otro carácter
+    ("NUMERO",         r"\d+\.?\d*"),  # Números enteros o decimales
+    ("IGUAL",          r"=="),           # Igual
+    ("NO_IGUAL",       r"!="),           # Distinto
+    ("MAYOR_IGUAL",    r">="),          # Mayor o igual
+    ("MENOR_IGUAL",    r"<="),          # Menor o igual
+    ("MAYOR_QUE",      r">"),           # Mayor que
+    ("MENOR_QUE",      r"<"),           # Menor que
+    ("ASIGNACION",     r"="),           # Asignación
+    ("OPERADOR",       r"[+\-*/^]"),   # Operadores aritméticos
+    ("PAREN_IZQ",      r"\("),         # Paréntesis izquierdo
+    ("PAREN_DER",      r"\)"),         # Paréntesis derecho
+    ("IDENTIFICADOR",  r"[A-Za-z_]+"),  # Identificadores
+    ("ESPACIO",        r"[ \t]+"),     # Espacios en blanco
+    ("DESCONOCIDO",    r".")           # Cualquier otro carácter
 ]
 
 def analizar(cadena: str) -> List[Token]:
@@ -33,9 +34,9 @@ def analizar(cadena: str) -> List[Token]:
     for match in regex.finditer(cadena):
         tipo = match.lastgroup
         valor = match.group()
-        if tipo == "SKIP":
+        if tipo == "ESPACIO":
             continue
-        if tipo == "MISMATCH":
+        if tipo == "DESCONOCIDO":
             raise ValueError(f"Carácter inesperado: {valor}")
         tokens.append(Token(tipo, valor))
     return tokens

--- a/analizador_lexico_gui.py
+++ b/analizador_lexico_gui.py
@@ -1,0 +1,98 @@
+import re
+from dataclasses import dataclass
+from typing import List
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+
+@dataclass
+class Token:
+    tipo: str
+    valor: str
+
+# Expresiones regulares para cada tipo de token
+TOKEN_SPEC = [
+    ("NUMBER",   r"\d+\.?\d*"),
+    ("EQ",       r"=="),
+    ("NE",       r"!="),
+    ("GE",       r">="),
+    ("LE",       r"<="),
+    ("GT",       r">"),
+    ("LT",       r"<"),
+    ("ASSIGN",   r"="),
+    ("OP",       r"[+\-*/^]"),
+    ("LPAREN",   r"\("),
+    ("RPAREN",   r"\)"),
+    ("IDENT",    r"[A-Za-z_]+"),
+    ("SKIP",     r"[ \t]+"),
+    ("MISMATCH", r".")
+]
+
+
+def analizar(cadena: str) -> List[Token]:
+    """Analiza la cadena y retorna una lista de tokens."""
+    token_regex = "|".join(f"(?P<{name}>{pattern})" for name, pattern in TOKEN_SPEC)
+    regex = re.compile(token_regex)
+    tokens: List[Token] = []
+    for match in regex.finditer(cadena):
+        tipo = match.lastgroup
+        valor = match.group()
+        if tipo == "SKIP":
+            continue
+        if tipo == "MISMATCH":
+            raise ValueError(f"Carácter inesperado: {valor}")
+        tokens.append(Token(tipo, valor))
+    return tokens
+
+
+def analizar_expresion() -> None:
+    """Toma la expresión del cuadro de texto y muestra los tokens."""
+    expresion = entrada.get()
+    tabla.delete(*tabla.get_children())
+    try:
+        for tok in analizar(expresion):
+            tabla.insert("", tk.END, values=(tok.valor, tok.tipo))
+    except ValueError as e:
+        messagebox.showerror("Error", str(e))
+
+
+def limpiar() -> None:
+    """Limpia la entrada y la tabla de tokens."""
+    entrada.delete(0, tk.END)
+    tabla.delete(*tabla.get_children())
+
+
+# Construcción de la interfaz
+raiz = tk.Tk()
+raiz.title("ANALIZADOR LEXICO")
+raiz.configure(bg="#0093ff")
+
+etiqueta = tk.Label(
+    raiz,
+    text="INGRESE LA EXPRESIÓN A VALIDAR",
+    bg="#0093ff",
+    fg="white",
+    font=("Arial", 12, "bold"),
+)
+etiqueta.pack(pady=(10, 5))
+
+entrada = tk.Entry(raiz, width=40)
+entrada.pack()
+
+botonera = tk.Frame(raiz, bg="#0093ff")
+botonera.pack(pady=5)
+
+btn_analizar = tk.Button(botonera, text="ANALIZAR", bg="#7fff00", command=analizar_expresion)
+btn_analizar.pack(side=tk.LEFT, padx=5)
+
+btn_limpiar = tk.Button(botonera, text="LIMPIAR", bg="#7fff00", command=limpiar)
+btn_limpiar.pack(side=tk.LEFT, padx=5)
+
+# Tabla para mostrar tokens
+columnas = ("Token", "Tipo")
+tabla = ttk.Treeview(raiz, columns=columnas, show="headings", height=8)
+for col in columnas:
+    tabla.heading(col, text=col)
+tabla.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+raiz.mainloop()

--- a/analizador_lexico_gui.py
+++ b/analizador_lexico_gui.py
@@ -10,22 +10,22 @@ class Token:
     tipo: str
     valor: str
 
-# Expresiones regulares para cada tipo de token
+# Expresiones regulares para cada tipo de token (nombres en español)
 TOKEN_SPEC = [
-    ("NUMBER",   r"\d+\.?\d*"),
-    ("EQ",       r"=="),
-    ("NE",       r"!="),
-    ("GE",       r">="),
-    ("LE",       r"<="),
-    ("GT",       r">"),
-    ("LT",       r"<"),
-    ("ASSIGN",   r"="),
-    ("OP",       r"[+\-*/^]"),
-    ("LPAREN",   r"\("),
-    ("RPAREN",   r"\)"),
-    ("IDENT",    r"[A-Za-z_]+"),
-    ("SKIP",     r"[ \t]+"),
-    ("MISMATCH", r".")
+    ("NUMERO",         r"\d+\.?\d*"),
+    ("IGUAL",          r"=="),
+    ("NO_IGUAL",       r"!="),
+    ("MAYOR_IGUAL",    r">="),
+    ("MENOR_IGUAL",    r"<="),
+    ("MAYOR_QUE",      r">"),
+    ("MENOR_QUE",      r"<"),
+    ("ASIGNACION",     r"="),
+    ("OPERADOR",       r"[+\-*/^]"),
+    ("PAREN_IZQ",      r"\("),
+    ("PAREN_DER",      r"\)"),
+    ("IDENTIFICADOR",  r"[A-Za-z_]+"),
+    ("ESPACIO",        r"[ \t]+"),
+    ("DESCONOCIDO",    r".")
 ]
 
 
@@ -37,9 +37,9 @@ def analizar(cadena: str) -> List[Token]:
     for match in regex.finditer(cadena):
         tipo = match.lastgroup
         valor = match.group()
-        if tipo == "SKIP":
+        if tipo == "ESPACIO":
             continue
-        if tipo == "MISMATCH":
+        if tipo == "DESCONOCIDO":
             raise ValueError(f"Carácter inesperado: {valor}")
         tokens.append(Token(tipo, valor))
     return tokens


### PR DESCRIPTION
## Summary
- Añade un script de Python que identifica números, variables, operadores y símbolos relacionales en una expresión.

## Testing
- `python analizador_lexico.py <<'EOF'
(2*x+5)-(x+y)=10>=8
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f1436d0832c81201f9bc897537d